### PR TITLE
Add basic AI assistant

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,34 +1,50 @@
 import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
 import './App.css'
 
 function App() {
-  const [count, setCount] = useState(0)
+  const [message, setMessage] = useState('')
+  const [conversation, setConversation] = useState([])
+
+  const sendMessage = async (e) => {
+    e.preventDefault()
+    const text = message.trim()
+    if (!text) return
+
+    setConversation((c) => [...c, { role: 'user', content: text }])
+    setMessage('')
+    try {
+      const res = await fetch('/api/ask', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: text })
+      })
+      const data = await res.json()
+      if (data.reply) {
+        setConversation((c) => [...c, { role: 'assistant', content: data.reply }])
+      }
+    } catch (err) {
+      console.error('Error sending message', err)
+    }
+  }
 
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
+    <div className="App">
+      <form onSubmit={sendMessage} className="form">
+        <input
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          placeholder="Введите сообщение"
+        />
+        <button type="submit">Отправить</button>
+      </form>
+      <div className="chat">
+        {conversation.map((m, idx) => (
+          <div key={idx} className={m.role}>
+            <strong>{m.role === 'user' ? 'Вы' : 'Ассистент'}:</strong> {m.content}
+          </div>
+        ))}
       </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.jsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    </div>
   )
 }
 

--- a/server/index.js
+++ b/server/index.js
@@ -1,12 +1,15 @@
 const express = require('express');
 const cors = require('cors');
 const dotenv = require('dotenv');
+const aiRouter = require('./routes/ai');
 
 dotenv.config();
 
 const app = express();
 app.use(cors({ origin: process.env.FRONTEND_URL || '*' }));
 app.use(express.json());
+
+app.use('/api/ask', aiRouter);
 
 app.get('/api/ping', (req, res) => {
   res.json({ status: 'pong' });

--- a/server/routes/ai.js
+++ b/server/routes/ai.js
@@ -1,0 +1,26 @@
+const express = require('express');
+const OpenAI = require('openai');
+
+const router = express.Router();
+
+router.post('/', async (req, res) => {
+  const { message } = req.body;
+  if (!message) {
+    return res.status(400).json({ error: 'Message is required' });
+  }
+
+  const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+  try {
+    const completion = await openai.chat.completions.create({
+      model: process.env.OPENAI_MODEL || 'gpt-3.5-turbo',
+      messages: [{ role: 'user', content: message }],
+    });
+    const reply = completion.choices?.[0]?.message?.content?.trim() || '';
+    res.json({ reply });
+  } catch (err) {
+    console.error('OpenAI error:', err);
+    res.status(500).json({ error: 'Failed to get response from AI' });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add AI route using OpenAI API in `server/routes/ai.js`
- mount the new route in the backend server
- replace React template with simple chat form

## Testing
- `npm --prefix client run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6865cc9828f0832c9d3e0f55d027203a