### PR TITLE
Add chat endpoint and update client

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -13,7 +13,7 @@ function App() {
     setConversation((c) => [...c, { role: 'user', content: text }])
     setMessage('')
     try {
-      const res = await fetch('/api/ask', {
+      const res = await fetch('/api/chat', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ message: text })

--- a/server/index.js
+++ b/server/index.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const cors = require('cors');
 const dotenv = require('dotenv');
+const { OpenAI } = require('openai');
 const aiRouter = require('./routes/ai');
 
 dotenv.config();
@@ -8,6 +9,22 @@ dotenv.config();
 const app = express();
 app.use(cors({ origin: process.env.FRONTEND_URL || '*' }));
 app.use(express.json());
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+app.post('/api/chat', async (req, res) => {
+  const { message } = req.body;
+  try {
+    const completion = await openai.chat.completions.create({
+      model: 'gpt-3.5-turbo',
+      messages: [{ role: 'user', content: message }],
+    });
+    res.json({ reply: completion.choices[0].message.content });
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: 'Ошибка при обращении к OpenAI' });
+  }
+});
 
 app.use('/api/ask', aiRouter);
 


### PR DESCRIPTION
## Summary
- add `OpenAI` integration in `server/index.js`
- expose `/api/chat` endpoint
- call new endpoint from React client

## Testing
- `npm --prefix ./client run lint`


------
https://chatgpt.com/codex/tasks/task_e_6865d0482430832c88a45c4b644aee69