### PR TITLE
Add scrollable chat history with auto scroll

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,16 +1,21 @@
-import { useState } from 'react'
+import { useState, useRef, useEffect } from 'react'
 import './App.css'
 
 function App() {
   const [message, setMessage] = useState('')
-  const [conversation, setConversation] = useState([])
+  const [messages, setMessages] = useState([])
+  const bottomRef = useRef(null)
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [messages])
 
   const sendMessage = async (e) => {
     e.preventDefault()
     const text = message.trim()
     if (!text) return
 
-    setConversation((c) => [...c, { role: 'user', content: text }])
+    setMessages((c) => [...c, { role: 'user', content: text }])
     setMessage('')
     try {
       const res = await fetch('/api/chat', {
@@ -20,7 +25,7 @@ function App() {
       })
       const data = await res.json()
       if (data.reply) {
-        setConversation((c) => [...c, { role: 'assistant', content: data.reply }])
+        setMessages((c) => [...c, { role: 'assistant', content: data.reply }])
       }
     } catch (err) {
       console.error('Error sending message', err)
@@ -37,13 +42,18 @@ function App() {
         />
         <button type="submit">Отправить</button>
       </form>
-      <div className="chat">
-        {conversation.map((m, idx) => (
-          <div key={idx} className={m.role}>
+      <div style={{ maxHeight: '400px', overflowY: 'auto', padding: '10px' }}>
+        {messages.map((m, idx) => (
+          <div
+            key={idx}
+            style={{ margin: '10px 0', color: m.role === 'user' ? '#0f0' : '#0ff' }}
+          >
             <strong>{m.role === 'user' ? 'Вы' : 'Ассистент'}:</strong> {m.content}
           </div>
         ))}
+        <div ref={bottomRef} />
       </div>
+      <button onClick={() => setMessages([])}>Очистить чат</button>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- keep chat history in `messages` state
- scroll chat container to bottom on new messages
- style chat messages and allow clearing history

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6865e2033324832c880f8bda9d0bb197