### PR TITLE
Add chat history support

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -15,13 +15,14 @@ function App() {
     const text = message.trim()
     if (!text) return
 
-    setMessages((c) => [...c, { role: 'user', content: text }])
+    const userMessage = { role: 'user', content: text }
+    setMessages((c) => [...c, userMessage])
     setMessage('')
     try {
       const res = await fetch('/api/chat', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ message: text })
+        body: JSON.stringify({ messages: [...messages, userMessage] })
       })
       const data = await res.json()
       if (data.reply) {

--- a/server/controllers/chatController.js
+++ b/server/controllers/chatController.js
@@ -5,14 +5,15 @@ const db = require('../db/knex');
 const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
 async function handleChatMessage(req, res) {
-  const { message } = req.body;
+  const { messages } = req.body;
   try {
     const completion = await openai.chat.completions.create({
       model: 'gpt-3.5-turbo',
-      messages: [{ role: 'user', content: message }],
+      messages: messages,
     });
     const reply = completion.choices?.[0]?.message?.content || '';
-    await db('messages').insert({ role: 'user', content: message });
+    const lastUserMessage = messages?.[messages.length - 1]?.content || '';
+    await db('messages').insert({ role: 'user', content: lastUserMessage });
     await db('messages').insert({ role: 'assistant', content: reply });
     res.json({ reply });
   } catch (error) {


### PR DESCRIPTION
## Summary
- send the chat history from the frontend when sending a new message
- update the server controller to use the provided history

## Testing
- `npm --prefix client run lint`

------
https://chatgpt.com/codex/tasks/task_e_6865e3300274832c9eccd97b8cc4ed4a