### PR TITLE
Add admin authentication and panel

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "react-router-dom": "^7.6.3"
       },
       "devDependencies": {
         "@eslint/js": "^9.29.0",
@@ -1599,6 +1600,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2470,6 +2480,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.3.tgz",
+      "integrity": "sha512-zf45LZp5skDC6I3jDLXQUu0u26jtuP4lEGbc7BbdyxenBN1vJSTA18czM2D+h5qyMBuMrD+9uB+mU37HIoKGRA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.6.3.tgz",
+      "integrity": "sha512-DiWJm9qdUAmiJrVWaeJdu4TKu13+iB/8IEi0EW/XgaHCjW/vWGrwzup0GVvaMteuZjKnh5bEvJP/K0MDnzawHw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.6.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -2535,6 +2583,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-router-dom": "^7.6.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",

--- a/client/src/Admin.jsx
+++ b/client/src/Admin.jsx
@@ -1,0 +1,162 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+export default function Admin() {
+  const navigate = useNavigate();
+  const token = localStorage.getItem('token');
+  const [businessDescription, setBusinessDescription] = useState('');
+  const [productInput, setProductInput] = useState('');
+  const [products, setProducts] = useState([]);
+  const [faqQuestion, setFaqQuestion] = useState('');
+  const [faqAnswer, setFaqAnswer] = useState('');
+  const [faqList, setFaqList] = useState([]);
+  const [saveStatus, setSaveStatus] = useState('');
+  const [logs, setLogs] = useState([]);
+
+  useEffect(() => {
+    if (!token) {
+      navigate('/login');
+      return;
+    }
+    (async () => {
+      try {
+        const res = await fetch('/api/knowledge', {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (res.ok) {
+          const data = await res.json();
+          setBusinessDescription(data.businessDescription || '');
+          setProducts(data.products || []);
+          setFaqList(data.faq || []);
+        }
+      } catch (err) {
+        console.error('Failed to load knowledge', err);
+      }
+    })();
+    (async () => {
+      try {
+        const res = await fetch('/api/chat/logs', {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (res.ok) {
+          const data = await res.json();
+          setLogs(data);
+        }
+      } catch (err) {
+        console.error('Failed to load logs', err);
+      }
+    })();
+  }, [token, navigate]);
+
+  const addProduct = () => {
+    const text = productInput.trim();
+    if (!text) return;
+    setProducts((c) => [...c, text]);
+    setProductInput('');
+  };
+
+  const addFaq = () => {
+    const q = faqQuestion.trim();
+    const a = faqAnswer.trim();
+    if (!q || !a) return;
+    setFaqList((c) => [...c, { question: q, answer: a }]);
+    setFaqQuestion('');
+    setFaqAnswer('');
+  };
+
+  const saveKnowledge = async () => {
+    try {
+      const res = await fetch('/api/knowledge', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ businessDescription, products, faq: faqList }),
+      });
+      if (res.ok) {
+        setSaveStatus('Сохранено');
+      } else {
+        setSaveStatus('Ошибка');
+      }
+    } catch (err) {
+      console.error('Failed to save knowledge', err);
+      setSaveStatus('Ошибка');
+    }
+    setTimeout(() => setSaveStatus(''), 3000);
+  };
+
+  const clearChat = async () => {
+    try {
+      await fetch('/api/chat/logs', {
+        method: 'DELETE',
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      setLogs([]);
+    } catch (err) {
+      console.error('Failed to clear chat', err);
+    }
+  };
+
+  const logout = () => {
+    localStorage.removeItem('token');
+    navigate('/login');
+  };
+
+  return (
+    <div style={{ padding: '20px' }}>
+      <button onClick={logout}>Выйти</button>
+      <h3>База знаний</h3>
+      <textarea
+        value={businessDescription}
+        onChange={(e) => setBusinessDescription(e.target.value)}
+        placeholder="Описание бизнеса"
+        rows={3}
+        style={{ width: '100%' }}
+      />
+      <div style={{ marginTop: '10px' }}>
+        <input
+          value={productInput}
+          onChange={(e) => setProductInput(e.target.value)}
+          placeholder="Добавить товар"
+        />
+        <button type="button" onClick={addProduct}>+</button>
+        <ul>
+          {products.map((p, i) => (
+            <li key={i}>{p}</li>
+          ))}
+        </ul>
+      </div>
+      <div style={{ marginTop: '10px' }}>
+        <input
+          value={faqQuestion}
+          onChange={(e) => setFaqQuestion(e.target.value)}
+          placeholder="Вопрос"
+        />
+        <input
+          value={faqAnswer}
+          onChange={(e) => setFaqAnswer(e.target.value)}
+          placeholder="Ответ"
+        />
+        <button type="button" onClick={addFaq}>Добавить</button>
+        <ul>
+          {faqList.map((f, i) => (
+            <li key={i}>{f.question} - {f.answer}</li>
+          ))}
+        </ul>
+      </div>
+      <button type="button" onClick={saveKnowledge}>Сохранить базу знаний</button>
+      {saveStatus && <span style={{ marginLeft: '10px' }}>{saveStatus}</span>}
+
+      <div style={{ marginTop: '20px' }}>
+        <h3>Логи чата</h3>
+        <button onClick={clearChat}>Очистить чат</button>
+        <ul>
+          {logs.map((m) => (
+            <li key={m.id}>{m.role}: {m.content}</li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,164 +1,17 @@
-import { useState, useRef, useEffect } from 'react'
-import './App.css'
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+import Login from './Login.jsx';
+import Admin from './Admin.jsx';
+import Chat from './Chat.jsx';
 
-function App() {
-  const [message, setMessage] = useState('')
-  const [messages, setMessages] = useState([])
-  const bottomRef = useRef(null)
-
-  const [businessDescription, setBusinessDescription] = useState('')
-  const [productInput, setProductInput] = useState('')
-  const [products, setProducts] = useState([])
-  const [faqQuestion, setFaqQuestion] = useState('')
-  const [faqAnswer, setFaqAnswer] = useState('')
-  const [faqList, setFaqList] = useState([])
-  const [saveStatus, setSaveStatus] = useState('')
-
-  useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
-  }, [messages])
-
-  useEffect(() => {
-    ;(async () => {
-      try {
-        const res = await fetch('/api/knowledge')
-        if (res.ok) {
-          const data = await res.json()
-          setBusinessDescription(data.businessDescription || '')
-          setProducts(data.products || [])
-          setFaqList(data.faq || [])
-        }
-      } catch (err) {
-        console.error('Failed to load knowledge', err)
-      }
-    })()
-  }, [])
-
-  const sendMessage = async (e) => {
-    e.preventDefault()
-    const text = message.trim()
-    if (!text) return
-
-    const userMessage = { role: 'user', content: text }
-    setMessages((c) => [...c, userMessage])
-    setMessage('')
-    try {
-      const res = await fetch('/api/chat', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ messages: [...messages, userMessage] })
-      })
-      const data = await res.json()
-      if (data.reply) {
-        setMessages((c) => [...c, { role: 'assistant', content: data.reply }])
-      }
-    } catch (err) {
-      console.error('Error sending message', err)
-    }
-  }
-
-  const addProduct = () => {
-    const text = productInput.trim()
-    if (!text) return
-    setProducts((c) => [...c, text])
-    setProductInput('')
-  }
-
-  const addFaq = () => {
-    const q = faqQuestion.trim()
-    const a = faqAnswer.trim()
-    if (!q || !a) return
-    setFaqList((c) => [...c, { question: q, answer: a }])
-    setFaqQuestion('')
-    setFaqAnswer('')
-  }
-
-  const saveKnowledge = async () => {
-    try {
-      const res = await fetch('/api/knowledge', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ businessDescription, products, faq: faqList })
-      })
-      if (res.ok) {
-        setSaveStatus('Сохранено')
-      } else {
-        setSaveStatus('Ошибка')
-      }
-    } catch (err) {
-      console.error('Failed to save knowledge', err)
-      setSaveStatus('Ошибка')
-    }
-    setTimeout(() => setSaveStatus(''), 3000)
-  }
-
+export default function App() {
   return (
-    <div className="App">
-      <div style={{ border: '1px solid #555', padding: '10px', marginBottom: '20px' }}>
-        <h3>База знаний</h3>
-        <textarea
-          value={businessDescription}
-          onChange={(e) => setBusinessDescription(e.target.value)}
-          placeholder="Описание бизнеса"
-          rows={3}
-          style={{ width: '100%' }}
-        />
-        <div style={{ marginTop: '10px' }}>
-          <input
-            value={productInput}
-            onChange={(e) => setProductInput(e.target.value)}
-            placeholder="Добавить товар"
-          />
-          <button type="button" onClick={addProduct}>+</button>
-          <ul>
-            {products.map((p, i) => (
-              <li key={i}>{p}</li>
-            ))}
-          </ul>
-        </div>
-        <div style={{ marginTop: '10px' }}>
-          <input
-            value={faqQuestion}
-            onChange={(e) => setFaqQuestion(e.target.value)}
-            placeholder="Вопрос"
-          />
-          <input
-            value={faqAnswer}
-            onChange={(e) => setFaqAnswer(e.target.value)}
-            placeholder="Ответ"
-          />
-          <button type="button" onClick={addFaq}>Добавить</button>
-          <ul>
-            {faqList.map((f, i) => (
-              <li key={i}>{f.question} - {f.answer}</li>
-            ))}
-          </ul>
-        </div>
-        <button type="button" onClick={saveKnowledge}>Сохранить базу знаний</button>
-        {saveStatus && <span style={{ marginLeft: '10px' }}>{saveStatus}</span>}
-      </div>
-      <form onSubmit={sendMessage} className="form">
-        <input
-          value={message}
-          onChange={(e) => setMessage(e.target.value)}
-          placeholder="Введите сообщение"
-        />
-        <button type="submit">Отправить</button>
-      </form>
-      <div style={{ maxHeight: '400px', overflowY: 'auto', padding: '10px' }}>
-        {messages.map((m, idx) => (
-          <div
-            key={idx}
-            style={{ margin: '10px 0', color: m.role === 'user' ? '#0f0' : '#0ff' }}
-          >
-            <strong>{m.role === 'user' ? 'Вы' : 'Ассистент'}:</strong> {m.content}
-          </div>
-        ))}
-        <div ref={bottomRef} />
-      </div>
-      <button onClick={() => setMessages([])}>Очистить чат</button>
-    </div>
-  )
+    <BrowserRouter>
+      <Routes>
+        <Route path="/login" element={<Login />} />
+        <Route path="/admin" element={<Admin />} />
+        <Route path="/chat" element={<Chat />} />
+        <Route path="*" element={<Navigate to="/login" replace />} />
+      </Routes>
+    </BrowserRouter>
+  );
 }
-
-export default App

--- a/client/src/Chat.jsx
+++ b/client/src/Chat.jsx
@@ -1,0 +1,164 @@
+import { useState, useRef, useEffect } from 'react'
+import './App.css'
+
+function Chat() {
+  const [message, setMessage] = useState('')
+  const [messages, setMessages] = useState([])
+  const bottomRef = useRef(null)
+
+  const [businessDescription, setBusinessDescription] = useState('')
+  const [productInput, setProductInput] = useState('')
+  const [products, setProducts] = useState([])
+  const [faqQuestion, setFaqQuestion] = useState('')
+  const [faqAnswer, setFaqAnswer] = useState('')
+  const [faqList, setFaqList] = useState([])
+  const [saveStatus, setSaveStatus] = useState('')
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [messages])
+
+  useEffect(() => {
+    ;(async () => {
+      try {
+        const res = await fetch('/api/knowledge')
+        if (res.ok) {
+          const data = await res.json()
+          setBusinessDescription(data.businessDescription || '')
+          setProducts(data.products || [])
+          setFaqList(data.faq || [])
+        }
+      } catch (err) {
+        console.error('Failed to load knowledge', err)
+      }
+    })()
+  }, [])
+
+  const sendMessage = async (e) => {
+    e.preventDefault()
+    const text = message.trim()
+    if (!text) return
+
+    const userMessage = { role: 'user', content: text }
+    setMessages((c) => [...c, userMessage])
+    setMessage('')
+    try {
+      const res = await fetch('/api/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ messages: [...messages, userMessage] })
+      })
+      const data = await res.json()
+      if (data.reply) {
+        setMessages((c) => [...c, { role: 'assistant', content: data.reply }])
+      }
+    } catch (err) {
+      console.error('Error sending message', err)
+    }
+  }
+
+  const addProduct = () => {
+    const text = productInput.trim()
+    if (!text) return
+    setProducts((c) => [...c, text])
+    setProductInput('')
+  }
+
+  const addFaq = () => {
+    const q = faqQuestion.trim()
+    const a = faqAnswer.trim()
+    if (!q || !a) return
+    setFaqList((c) => [...c, { question: q, answer: a }])
+    setFaqQuestion('')
+    setFaqAnswer('')
+  }
+
+  const saveKnowledge = async () => {
+    try {
+      const res = await fetch('/api/knowledge', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ businessDescription, products, faq: faqList })
+      })
+      if (res.ok) {
+        setSaveStatus('Сохранено')
+      } else {
+        setSaveStatus('Ошибка')
+      }
+    } catch (err) {
+      console.error('Failed to save knowledge', err)
+      setSaveStatus('Ошибка')
+    }
+    setTimeout(() => setSaveStatus(''), 3000)
+  }
+
+  return (
+    <div className="App">
+      <div style={{ border: '1px solid #555', padding: '10px', marginBottom: '20px' }}>
+        <h3>База знаний</h3>
+        <textarea
+          value={businessDescription}
+          onChange={(e) => setBusinessDescription(e.target.value)}
+          placeholder="Описание бизнеса"
+          rows={3}
+          style={{ width: '100%' }}
+        />
+        <div style={{ marginTop: '10px' }}>
+          <input
+            value={productInput}
+            onChange={(e) => setProductInput(e.target.value)}
+            placeholder="Добавить товар"
+          />
+          <button type="button" onClick={addProduct}>+</button>
+          <ul>
+            {products.map((p, i) => (
+              <li key={i}>{p}</li>
+            ))}
+          </ul>
+        </div>
+        <div style={{ marginTop: '10px' }}>
+          <input
+            value={faqQuestion}
+            onChange={(e) => setFaqQuestion(e.target.value)}
+            placeholder="Вопрос"
+          />
+          <input
+            value={faqAnswer}
+            onChange={(e) => setFaqAnswer(e.target.value)}
+            placeholder="Ответ"
+          />
+          <button type="button" onClick={addFaq}>Добавить</button>
+          <ul>
+            {faqList.map((f, i) => (
+              <li key={i}>{f.question} - {f.answer}</li>
+            ))}
+          </ul>
+        </div>
+        <button type="button" onClick={saveKnowledge}>Сохранить базу знаний</button>
+        {saveStatus && <span style={{ marginLeft: '10px' }}>{saveStatus}</span>}
+      </div>
+      <form onSubmit={sendMessage} className="form">
+        <input
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          placeholder="Введите сообщение"
+        />
+        <button type="submit">Отправить</button>
+      </form>
+      <div style={{ maxHeight: '400px', overflowY: 'auto', padding: '10px' }}>
+        {messages.map((m, idx) => (
+          <div
+            key={idx}
+            style={{ margin: '10px 0', color: m.role === 'user' ? '#0f0' : '#0ff' }}
+          >
+            <strong>{m.role === 'user' ? 'Вы' : 'Ассистент'}:</strong> {m.content}
+          </div>
+        ))}
+        <div ref={bottomRef} />
+      </div>
+      <button onClick={() => setMessages([])}>Очистить чат</button>
+    </div>
+  )
+}
+
+export default Chat

--- a/client/src/Login.jsx
+++ b/client/src/Login.jsx
@@ -1,0 +1,54 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+export default function Login() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+    try {
+      const res = await fetch('/api/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        localStorage.setItem('token', data.token);
+        navigate('/admin');
+      } else {
+        setError('Неверные учетные данные');
+      }
+    } catch (err) {
+      console.error('Login error', err);
+      setError('Ошибка входа');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} style={{ maxWidth: 300, margin: '50px auto' }}>
+      <h2>Вход</h2>
+      <div>
+        <input
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="Email"
+        />
+      </div>
+      <div>
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder="Пароль"
+        />
+      </div>
+      <button type="submit">Войти</button>
+      {error && <div style={{ color: 'red' }}>{error}</div>}
+    </form>
+  );
+}

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1,10 +1,10 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.jsx'
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import './index.css';
+import App from './App.jsx';
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <App />
   </StrictMode>,
-)
+);

--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -1,0 +1,40 @@
+const fs = require('fs').promises;
+const path = require('path');
+const bcrypt = require('bcrypt');
+const jwt = require('jsonwebtoken');
+
+const usersFile = path.join(__dirname, '..', 'users.json');
+
+async function findUser(email) {
+  try {
+    const data = await fs.readFile(usersFile, 'utf-8');
+    const users = JSON.parse(data);
+    return users.find(u => u.email === email);
+  } catch (err) {
+    return null;
+  }
+}
+
+async function login(req, res) {
+  const { email, password } = req.body || {};
+  if (!email || !password) {
+    return res.status(400).json({ error: 'Email and password required' });
+  }
+  try {
+    const user = await findUser(email);
+    if (!user) {
+      return res.status(401).json({ error: 'Invalid credentials' });
+    }
+    const match = await bcrypt.compare(password, user.password);
+    if (!match) {
+      return res.status(401).json({ error: 'Invalid credentials' });
+    }
+    const token = jwt.sign({ email: user.email, role: user.role }, process.env.JWT_SECRET || 'secret', { expiresIn: '1h' });
+    res.json({ token });
+  } catch (err) {
+    console.error('Login error:', err);
+    res.status(500).json({ error: 'Server error' });
+  }
+}
+
+module.exports = { login };

--- a/server/index.js
+++ b/server/index.js
@@ -4,6 +4,7 @@ const dotenv = require('dotenv');
 const aiRouter = require('./routes/ai');
 const chatRoutes = require('./routes/chatRoutes');
 const knowledgeRoutes = require('./routes/knowledgeRoutes');
+const authRoutes = require('./routes/authRoutes');
 const initDb = require('./db/init');
 
 dotenv.config();
@@ -14,10 +15,9 @@ app.use(express.json());
 
 initDb();
 
+app.use('/api/auth', authRoutes);
 app.use('/api/chat', chatRoutes);
-
 app.use('/api/knowledge', knowledgeRoutes);
-
 app.use('/api/ask', aiRouter);
 
 app.get('/api/ping', (req, res) => {

--- a/server/middleware/authMiddleware.js
+++ b/server/middleware/authMiddleware.js
@@ -1,0 +1,25 @@
+const jwt = require('jsonwebtoken');
+
+function authMiddleware(req, res, next) {
+  const authHeader = req.headers.authorization || '';
+  const token = authHeader.split(' ')[1];
+  if (!token) {
+    return res.status(401).json({ error: 'No token' });
+  }
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET || 'secret');
+    req.user = { email: decoded.email, role: decoded.role };
+    next();
+  } catch (err) {
+    return res.status(401).json({ error: 'Invalid token' });
+  }
+}
+
+function adminOnly(req, res, next) {
+  if (req.user?.role !== 'admin') {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+  next();
+}
+
+module.exports = { authMiddleware, adminOnly };

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,9 +9,11 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "bcrypt": "^6.0.0",
         "cors": "^2.8.5",
         "dotenv": "^17.0.1",
         "express": "^5.1.0",
+        "jsonwebtoken": "^9.0.2",
         "knex": "^3.1.0",
         "openai": "^5.8.2",
         "sqlite3": "^5.1.7"
@@ -196,6 +198,29 @@
       ],
       "license": "MIT"
     },
+    "node_modules/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/bcrypt/node_modules/node-addon-api": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.4.0.tgz",
+      "integrity": "sha512-D9DI/gXHvVmjHS08SVch0Em8G5S1P+QWtU31appcKT/8wFSPRcdHadIFSAntdMMVM5zz+/DL+bL/gz3UDppqtg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -296,6 +321,12 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -590,6 +621,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -1332,6 +1372,49 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/knex": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/knex/-/knex-3.1.0.tgz",
@@ -1410,6 +1493,48 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/lru-cache": {
@@ -1723,6 +1848,17 @@
       },
       "engines": {
         "node": ">= 10.12.0"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/nodemon": {

--- a/server/package.json
+++ b/server/package.json
@@ -12,9 +12,11 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
+    "bcrypt": "^6.0.0",
     "cors": "^2.8.5",
     "dotenv": "^17.0.1",
     "express": "^5.1.0",
+    "jsonwebtoken": "^9.0.2",
     "knex": "^3.1.0",
     "openai": "^5.8.2",
     "sqlite3": "^5.1.7"

--- a/server/routes/authRoutes.js
+++ b/server/routes/authRoutes.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const { login } = require('../controllers/authController');
+
+const router = express.Router();
+
+router.post('/login', login);
+
+module.exports = router;

--- a/server/routes/chatRoutes.js
+++ b/server/routes/chatRoutes.js
@@ -1,8 +1,11 @@
 const express = require('express');
-const { handleChatMessage } = require('../controllers/chatController');
+const { handleChatMessage, getChatLogs, clearChat } = require('../controllers/chatController');
+const { authMiddleware, adminOnly } = require('../middleware/authMiddleware');
 
 const router = express.Router();
 
 router.post('/', handleChatMessage);
+router.get('/logs', authMiddleware, adminOnly, getChatLogs);
+router.delete('/logs', authMiddleware, adminOnly, clearChat);
 
 module.exports = router;

--- a/server/routes/knowledgeRoutes.js
+++ b/server/routes/knowledgeRoutes.js
@@ -1,9 +1,10 @@
 const express = require('express');
 const { getKnowledge, saveKnowledge } = require('../controllers/knowledgeController');
+const { authMiddleware, adminOnly } = require('../middleware/authMiddleware');
 
 const router = express.Router();
 
-router.get('/', getKnowledge);
-router.post('/', saveKnowledge);
+router.get('/', authMiddleware, adminOnly, getKnowledge);
+router.post('/', authMiddleware, adminOnly, saveKnowledge);
 
 module.exports = router;

--- a/server/users.json
+++ b/server/users.json
@@ -1,0 +1,7 @@
+[
+  {
+    "email": "admin@example.com",
+    "password": "$2b$10$cCXIOiJfefhwjKoJwnLMe.diXI/jGb.GRW.VKYim8nkKsrtYzsyMm",
+    "role": "admin"
+  }
+]


### PR DESCRIPTION
## Summary
- implement JWT login API for admin
- create authentication middleware for protected routes
- protect knowledge and chat log APIs for admin role
- add endpoints to view and clear chat logs
- update server packages for bcrypt and jsonwebtoken
- build React admin panel with login and knowledge base editor
- add simple chat component and routing

## Testing
- `npm run lint` in `client`
- `npm test` in `server` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6865ed9adc2c832c8e953ab231b9b082