### PR TITLE
feat(ig): add webhook verification route and POST placeholder

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -7,6 +7,7 @@ import { registerSettingsRoutes } from './routes/settings.js';
 import { registerChatRoutes } from './routes/chat.js';
 import { registerModelsRoutes } from './routes/models.js';
 import { registerUsageRoutes } from './routes/usage.js';
+import { registerIGRoutes } from './routes/ig.js';
 
 const app = Fastify({ logger });
 
@@ -19,6 +20,7 @@ await registerSettingsRoutes(app);
 await registerChatRoutes(app);
 await registerModelsRoutes(app);
 await registerUsageRoutes(app);
+await registerIGRoutes(app);
 
 const port = Number(process.env.API_PORT ?? 8787);
 app.listen({ port, host: '0.0.0.0' }).then(() => {

--- a/server/src/routes/ig.ts
+++ b/server/src/routes/ig.ts
@@ -1,0 +1,21 @@
+import type { FastifyInstance } from 'fastify';
+
+export async function registerIGRoutes(app: FastifyInstance) {
+  // Верификация вебхука от Meta (GET)
+  app.get('/api/ig/webhook', async (req, reply) => {
+    const q = (req.query ?? {}) as Record<string, any>;
+    const mode = q['hub.mode'] || q.hub_mode;
+    const token = q['hub.verify_token'] || q.hub_verify_token;
+    const challenge = q['hub.challenge'] || q.hub_challenge;
+
+    if (mode === 'subscribe' && token === (process.env.META_VERIFY_TOKEN || '')) {
+      return reply.code(200).send(challenge);
+    }
+    return reply.code(403).send('Forbidden');
+  });
+
+  // Заглушка обработчика событий (POST) — реализуем в IG-1.2
+  app.post('/api/ig/webhook', async (_req, reply) => {
+    return reply.code(200).send('ok');
+  });
+}


### PR DESCRIPTION
## Summary
- add Instagram webhook verification endpoint
- register IG routes in server

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Cannot find module 'fastify', 'fastify-helmet', etc.)*
- `npm run dev` *(fails: tsx: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aee893bd2c832c9c502a263806425e