### PR TITLE
feat(ig): subscribe endpoint for FB Page messaging

### DIFF
--- a/server/src/routes/ig.ts
+++ b/server/src/routes/ig.ts
@@ -18,4 +18,23 @@ export async function registerIGRoutes(app: FastifyInstance) {
   app.post('/api/ig/webhook', async (_req, reply) => {
     return reply.code(200).send('ok');
   });
+
+  // Ручная подписка на вебхук (выполняется один раз при настройке)
+  app.post('/api/ig/subscribe', async (_req, reply) => {
+    const pageId = process.env.FB_PAGE_ID || '';
+    const token = process.env.PAGE_ACCESS_TOKEN || '';
+
+    if (!pageId || !token) {
+      return reply.code(400).send({ error: 'Missing FB_PAGE_ID or PAGE_ACCESS_TOKEN' });
+    }
+
+    const url = `https://graph.facebook.com/v19.0/${pageId}/subscribed_apps?access_token=${encodeURIComponent(token)}`;
+    const r = await fetch(url, { method: 'POST' });
+    const data = await r.json().catch(() => ({}));
+
+    if (!r.ok) {
+      return reply.code(500).send({ error: 'subscribe failed', data });
+    }
+    return { ok: true, data };
+  });
 }


### PR DESCRIPTION
## Summary
- add `/api/ig/subscribe` endpoint to trigger Facebook Page webhook subscription

## Testing
- `pnpm build` (failed: Cannot find module 'fastify' or its corresponding type declarations)
- `pnpm install` (failed: No matching version found for fastify-cors@^8.4.2)
- `pnpm dev` (failed: tsx: not found)
- `curl -X POST http://localhost:8787/api/ig/subscribe` (failed: Couldn't connect to server)


------
https://chatgpt.com/codex/tasks/task_e_68aeeaa59d94832c98dcfaf709c75b1a