### PR TITLE
feat(db): add Prisma models for IG contacts, threads, events

### DIFF
--- a/server/prisma/migrations/20250827114312_ig_contacts_threads_events/migration.sql
+++ b/server/prisma/migrations/20250827114312_ig_contacts_threads_events/migration.sql
@@ -1,0 +1,39 @@
+-- CreateTable
+CREATE TABLE "IgContact" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "igUserId" TEXT NOT NULL,
+    "username" TEXT,
+    "fullName" TEXT,
+    "locale" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "status" TEXT NOT NULL DEFAULT 'bot',
+    "notes" TEXT
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "IgContact_igUserId_key" ON "IgContact"("igUserId");
+
+-- CreateTable
+CREATE TABLE "IgThread" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "contactId" TEXT NOT NULL,
+    "pageId" TEXT,
+    "state" TEXT NOT NULL DEFAULT 'active',
+    "lastMessageAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "IgThread_contactId_fkey" FOREIGN KEY ("contactId") REFERENCES "IgContact" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "IgEvent" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "threadId" TEXT NOT NULL,
+    "direction" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "text" TEXT,
+    "payload" TEXT,
+    "at" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "IgEvent_threadId_fkey" FOREIGN KEY ("threadId") REFERENCES "IgThread" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);

--- a/server/prisma/migrations/migration_lock.toml
+++ b/server/prisma/migrations/migration_lock.toml
@@ -1,0 +1,3 @@
+# Prisma Migrate lock file
+# This file should be committed to your repository.
+provider = "sqlite"

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -1,0 +1,46 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = env("DATABASE_URL")
+}
+
+// existing models would go here
+
+model IgContact {
+  id            String   @id @default(cuid())
+  igUserId      String   @unique // PSID пользователя из IG
+  username      String?          // если доступно через дополнительные запросы
+  fullName      String?
+  locale        String?
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+  threads       IgThread[]
+  status        String   @default("bot") // bot | manager | muted
+  notes         String?
+}
+
+model IgThread {
+  id            String   @id @default(cuid())
+  contactId     String
+  contact       IgContact @relation(fields: [contactId], references: [id], onDelete: Cascade)
+  pageId        String?   // FB Page ID
+  state         String    @default("active") // active | archived
+  lastMessageAt DateTime  @default(now())
+  createdAt     DateTime  @default(now())
+  updatedAt     DateTime  @updatedAt
+  events        IgEvent[]
+}
+
+model IgEvent {
+  id         String   @id @default(cuid())
+  threadId   String
+  thread     IgThread @relation(fields: [threadId], references: [id], onDelete: Cascade)
+  direction  String   // in | out
+  type       String   // text | attachment | postback | system
+  text       String?
+  payload    Json?
+  at         DateTime @default(now())
+}


### PR DESCRIPTION
## Summary
- add Prisma models for IG contacts, threads, and events
- create initial migration for new IG models

## Testing
- `pnpm prisma:generate` *(fails: prisma not found)*
- `pnpm dlx prisma@5.16.1 generate` *(fails: 403 downloading Prisma engine)*
- `pnpm prisma:migrate -n ig_contacts_threads_events` *(fails: prisma not found)*
- `pnpm dlx prisma@5.16.1 migrate dev -n ig_contacts_threads_events` *(fails: 403 downloading Prisma engine)*

------
https://chatgpt.com/codex/tasks/task_e_68aeee7093e0832ca84739ef23f1cf60