### PR TITLE
feat(ig): add IgRule model, keyword-based replies, START command, cooldown, API to manage rules

### DIFF
--- a/server/prisma/migrations/20250827120000_ig_rules/migration.sql
+++ b/server/prisma/migrations/20250827120000_ig_rules/migration.sql
@@ -1,0 +1,9 @@
+-- CreateTable
+CREATE TABLE "IgRule" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "keyword" TEXT NOT NULL,
+    "reply" TEXT NOT NULL,
+    "active" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -44,3 +44,12 @@ model IgEvent {
   payload    Json?
   at         DateTime @default(now())
 }
+
+model IgRule {
+  id        String   @id @default(cuid())
+  keyword   String
+  reply     String
+  active    Boolean  @default(true)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -8,6 +8,7 @@ import { registerChatRoutes } from './routes/chat.js';
 import { registerModelsRoutes } from './routes/models.js';
 import { registerUsageRoutes } from './routes/usage.js';
 import { registerIGRoutes } from './routes/ig.js';
+import { registerIgRulesRoutes } from './routes/igRules.js';
 
 const app = Fastify({ logger });
 
@@ -21,6 +22,7 @@ await registerChatRoutes(app);
 await registerModelsRoutes(app);
 await registerUsageRoutes(app);
 await registerIGRoutes(app);
+await registerIgRulesRoutes(app);
 
 const port = Number(process.env.API_PORT ?? 8787);
 app.listen({ port, host: '0.0.0.0' }).then(() => {

--- a/server/src/routes/igRules.ts
+++ b/server/src/routes/igRules.ts
@@ -1,0 +1,27 @@
+import type { FastifyInstance } from 'fastify';
+import { prisma } from '../prisma.js';
+
+export async function registerIgRulesRoutes(app: FastifyInstance) {
+  // список правил
+  app.get('/api/ig/rules', async () => {
+    return prisma.igRule.findMany({ orderBy: { createdAt: 'desc' } });
+  });
+
+  // создать правило
+  app.post('/api/ig/rules', async (req, reply) => {
+    const { keyword, reply: answer } = req.body as any;
+    if (!keyword || !answer) return reply.code(400).send({ error: 'keyword and reply required' });
+    const rule = await prisma.igRule.create({ data: { keyword, reply: answer } });
+    return rule;
+  });
+
+  // выключить правило
+  app.put('/api/ig/rules/:id/toggle', async (req, reply) => {
+    const { id } = req.params as any;
+    const rule = await prisma.igRule.update({
+      where: { id },
+      data: { active: { set: false } }
+    });
+    return rule;
+  });
+}

--- a/server/src/services/igRules.ts
+++ b/server/src/services/igRules.ts
@@ -31,6 +31,16 @@ export async function applyRules({
   contactId: string;
   text?: string;
 }): Promise<RuleResult> {
+  const now = new Date();
+
+  // 0) Проверить кулдаун (антиспам) — последнее исходящее событие <30с
+  const lastOut = await prisma.igEvent.findFirst({
+    where: { thread: { contactId }, direction: 'out' },
+    orderBy: { at: 'desc' }
+  });
+  if (lastOut && now.getTime() - lastOut.at.getTime() < 30_000) {
+    return { action: 'none' }; // пропускаем автоответ
+  }
 
   // 1) STOP → mute
   if (isStop(text)) {
@@ -38,7 +48,16 @@ export async function applyRules({
       where: { id: contactId },
       data: { status: 'muted' }
     });
-    return { action: 'mute', reply: 'Вы отписались от автоответов. Если захотите продолжить — напишите «Старт».' };
+    return { action: 'mute', reply: 'Вы отписались от автоответов. Напишите «Старт», чтобы включить снова.' };
+  }
+
+  // 1b) START → вернуться из mute
+  if (text && text.trim().toLowerCase().includes('старт')) {
+    await prisma.igContact.update({
+      where: { id: contactId },
+      data: { status: 'bot' }
+    });
+    return { action: 'greet', reply: 'Автоответы снова активированы ✅' };
   }
 
   // 2) Хенд-офф менеджеру
@@ -50,12 +69,23 @@ export async function applyRules({
     return { action: 'handoff', reply: 'Передал ваш диалог менеджеру. Он скоро ответит.' };
   }
 
-  // 3) Ночной режим (если контакт не в режиме manager/muted)
+  // 3) Ночной режим
   const contact = await prisma.igContact.findUnique({ where: { id: contactId } });
-  if (contact && contact.status === 'bot' && isNight()) {
+  if (contact && contact.status === 'bot' && isNight(now)) {
     return { action: 'night', reply: 'Спасибо за сообщение! Сейчас нерабочее время — мы ответим утром.' };
   }
 
-  // 4) Базовое приветствие/разогрев (первая реплика без истории или по умолчанию)
-  return { action: 'greet', reply: 'Привет! Я онлайн-ассистент. Расскажите, что вас интересует, и я помогу 😊' };
+  // 4) Поиск по ключевым словам (IgRule)
+  if (text) {
+    const rules = await prisma.igRule.findMany({ where: { active: true } });
+    const lower = text.toLowerCase();
+    for (const rule of rules) {
+      if (lower.includes(rule.keyword.toLowerCase())) {
+        return { action: 'greet', reply: rule.reply };
+      }
+    }
+  }
+
+  // 5) Базовое приветствие
+  return { action: 'greet', reply: 'Привет! Я онлайн-ассистент. Расскажите, что вас интересует 😊' };
 }


### PR DESCRIPTION
## Summary
- add IgRule Prisma model and migration
- extend IG auto-response service with cooldown, START command and keyword-based replies
- expose API routes to list, create and disable IG rules

## Testing
- `pnpm prisma:generate` *(fails: prisma: not found)*
- `pnpm prisma:migrate -n ig_rules` *(fails: prisma: not found)*
- `pnpm build` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68aef2e2ba20832cb9931c16a87f589f