### PR TITLE
Add IG quick reply handling and stats

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -4,6 +4,7 @@ import BusinessSettings from './BusinessSettings';
 import IgRules from './IgRules';
 import IgDialogs from './IgDialogs';
 import IgSettings from './IgSettings';
+import IgStats from './IgStats';
 
 export default function App() {
   const [tab, setTab] = useState('chat');
@@ -16,12 +17,14 @@ export default function App() {
         <button onClick={() => setTab('ig_rules')}>IG Rules</button>
         <button onClick={() => setTab('ig_dialogs')}>IG Dialogs</button>
         <button onClick={() => setTab('ig_settings')}>IG Settings</button>
+        <button onClick={() => setTab('ig_stats')}>IG Stats</button>
       </nav>
       {tab === 'chat' && <Chat />}
       {tab === 'settings' && <BusinessSettings />}
       {tab === 'ig_rules' && <IgRules />}
       {tab === 'ig_dialogs' && <IgDialogs />}
       {tab === 'ig_settings' && <IgSettings />}
+      {tab === 'ig_stats' && <IgStats />}
     </div>
   );
 }

--- a/client/src/IgStats.jsx
+++ b/client/src/IgStats.jsx
@@ -1,0 +1,57 @@
+import React, { useEffect, useState } from 'react';
+import { igQuickStats } from './api';
+
+export default function IgStats() {
+  const [items, setItems] = useState([]);
+  const [total, setTotal] = useState(0);
+  const [from, setFrom] = useState('');
+  const [to, setTo] = useState('');
+  const [status, setStatus] = useState('');
+
+  async function load() {
+    try {
+      const data = await igQuickStats({ from, to });
+      setItems(data.items || []);
+      setTotal(data.total || 0);
+      setStatus('');
+    } catch {
+      setStatus('Ошибка загрузки статистики');
+    }
+  }
+
+  useEffect(() => { load(); /* eslint-disable-next-line */ }, []);
+
+  return (
+    <div style={{ maxWidth: 800, margin: '20px auto', padding: 12 }}>
+      <h2>IG Stats — Quick Replies</h2>
+
+      <div style={{ display: 'flex', gap: 8, alignItems: 'center', marginBottom: 10 }}>
+        <label>From</label>
+        <input type="date" value={from} onChange={e => setFrom(e.target.value)} />
+        <label>To</label>
+        <input type="date" value={to} onChange={e => setTo(e.target.value)} />
+        <button onClick={load}>Обновить</button>
+        <span style={{ marginLeft: 'auto' }}>Всего: {total}</span>
+      </div>
+
+      <div style={{ minHeight: 20, marginBottom: 6 }}>{status}</div>
+
+      <table width="100%" border="1" cellPadding="6" style={{ borderCollapse: 'collapse' }}>
+        <thead>
+          <tr>
+            <th>Кнопка</th>
+            <th>Нажатий</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((x, i) => (
+            <tr key={i}>
+              <td>{x.title}</td>
+              <td>{x.count}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -143,3 +143,11 @@ export async function igSaveSettings({ tz, quietStart, quietEnd, quickReplies })
   return r.json();
 }
 
+// IG Stats
+export async function igQuickStats(params = {}) {
+  const q = new URLSearchParams(params).toString();
+  const r = await fetch(`/api/ig/stats/quick${q ? `?${q}` : ''}`);
+  if (!r.ok) throw new Error('quick stats fetch failed');
+  return r.json();
+}
+


### PR DESCRIPTION
## Summary
- handle Quick Replies in IG webhook with spam protection and journaling
- expose quick reply stats endpoint in IG admin API
- add client API binding, stats page, and navigation tab

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm --prefix server run build` *(fails: TS errors: Parameter 'reply' implicitly has an 'any' type, Cannot find module 'fastify', etc.)*
- `npm --prefix client run build`


------
https://chatgpt.com/codex/tasks/task_e_68aefb70ff74832cb6e4ebfabee409d4