### PR TITLE
feat(flows): extend triggers and support import/export

### DIFF
--- a/client/src/Flows.jsx
+++ b/client/src/Flows.jsx
@@ -1,5 +1,51 @@
 import React, { useEffect, useState } from 'react';
-import { flowsList, flowsCreate, flowsUpdate, flowTriggers, flowTriggerCreate, flowTriggerToggle } from './api';
+import { flowsList, flowsCreate, flowsUpdate, flowTriggers, flowTriggerCreate, flowTriggerToggle, flowExport, flowImport, flowTriggerUpdate } from './api';
+
+// Predefined flow templates
+const PRESETS = [
+  {
+    label: 'E-commerce: Быстрый квиз',
+    flow: {
+      name: 'Ecom Quick Quiz',
+      entry: 'start',
+      nodes: {
+        start: { type:'sendText', text:'Привет! Помогу подобрать товар 👍', next:'q1' },
+        q1:    { type:'sendQuick', text:'Что важнее?', quick:['Цена','Качество','Сроки'], next:'q2' },
+        q2:    { type:'sendQuick', text:'Куда доставлять?', quick:['По городу','По стране','Международно'], next:'handoff' },
+        handoff: { type:'handoff' }
+      }
+    },
+    triggers: [{ kind:'keyword', value:'купить' }]
+  },
+  {
+    label: 'Beauty: Запись на услугу',
+    flow: {
+      name: 'Beauty Lead',
+      entry: 'start',
+      nodes: {
+        start: { type:'sendText', text:'Здравствуйте! Помогу с записью 💅', next:'q1' },
+        q1:    { type:'sendQuick', text:'Какая услуга интересует?', quick:['Маникюр','Педикюр','Комплект'], next:'q2' },
+        q2:    { type:'sendQuick', text:'Когда удобно?', quick:['Сегодня','Завтра','На неделе'], next:'handoff' },
+        handoff: { type:'handoff' }
+      }
+    },
+    triggers: [{ kind:'keyword', value:'запись' }]
+  },
+  {
+    label: 'Restaurant: Бронирование',
+    flow: {
+      name: 'Restaurant Booking',
+      entry: 'start',
+      nodes: {
+        start: { type:'sendText', text:'Здравствуйте! Помогу забронировать столик 🍽️', next:'q1' },
+        q1:    { type:'sendQuick', text:'На сколько персон?', quick:['2','4','6+'], next:'q2' },
+        q2:    { type:'sendQuick', text:'Когда?', quick:['Сегодня','Завтра','На выходных'], next:'handoff' },
+        handoff: { type:'handoff' }
+      }
+    },
+    triggers: [{ kind:'keyword', value:'бронь' }]
+  }
+];
 
 export default function Flows() {
   const [items, setItems] = useState([]);
@@ -9,6 +55,11 @@ export default function Flows() {
   const [nodes, setNodes] = useState('{\n  "start": { "type":"sendText", "text":"Привет!", "next":"q1" },\n  "q1": { "type":"sendQuick", "text":"Чем помочь?", "quick":["Цена","Доставка","Менеджер"] }\n}');
   const [trigs, setTrigs] = useState([]);
   const [tVal, setTVal] = useState('');
+  const [tKind, setTKind] = useState('keyword');
+  const [tStart, setTStart] = useState('');
+  const [tEnd, setTEnd] = useState('');
+  const [tDaysMask, setTDaysMask] = useState('');
+  const [preset, setPreset] = useState(PRESETS[0]);
 
   async function load() {
     const list = await flowsList();
@@ -36,9 +87,14 @@ export default function Flows() {
   }
 
   async function addTrig() {
-    if (!sel || !tVal) return;
-    await flowTriggerCreate(sel.id, { kind: 'keyword', value: tVal });
-    setTVal('');
+    if (!sel) return;
+    await flowTriggerCreate(sel.id, {
+      kind: tKind, value: tVal,
+      startAt: tStart || undefined,
+      endAt: tEnd || undefined,
+      daysMask: tDaysMask ? Number(tDaysMask) : undefined
+    });
+    setTVal(''); setTKind('keyword'); setTStart(''); setTEnd(''); setTDaysMask('');
     setTrigs(await flowTriggers(sel.id));
   }
 
@@ -53,8 +109,19 @@ export default function Flows() {
             </div>
           ))}
         </div>
-        <div style={{ marginTop: 12 }}>
+        <div style={{ marginTop: 12, display:'flex', gap:8, flexWrap:'wrap' }}>
           <button onClick={create}>+ Новый Flow</button>
+          <button onClick={async ()=>{
+            const p = preset;
+            const created = await flowsCreate({ name: p.flow.name, entry: p.flow.entry, nodes: p.flow.nodes });
+            for (const t of p.triggers) {
+              await flowTriggerCreate(created.id, t);
+            }
+            await load(); setSel(created); pick(created);
+          }}>Create from preset</button>
+          <select value={preset.label} onChange={e=> setPreset(PRESETS.find(x=>x.label===e.target.value))}>
+            {PRESETS.map(p=><option key={p.label}>{p.label}</option>)}
+          </select>
         </div>
       </div>
 
@@ -67,17 +134,53 @@ export default function Flows() {
           <button onClick={save} disabled={!sel}>Сохранить</button>
         </div>
 
+        <div style={{ marginTop:8 }}>
+          <button onClick={async ()=>{
+            if (!sel) return;
+            const data = await flowExport(sel.id);
+            const blob = new Blob([JSON.stringify(data, null, 2)], { type:'application/json' });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url; a.download = `${sel.name.replace(/\s+/g,'_')}.flow.json`;
+            a.click(); URL.revokeObjectURL(url);
+          }}>Export</button>
+
+          <label style={{ marginLeft: 8 }}>
+            Import (.flow.json)
+            <input type="file" accept="application/json" onChange={async (e)=>{
+              const file = e.target.files?.[0]; if(!file) return;
+              const txt = await file.text();
+              await flowImport(JSON.parse(txt));
+              load();
+            }} />
+          </label>
+        </div>
+
         {sel && (
           <div style={{ marginTop: 16 }}>
             <h4>Триггеры</h4>
-            <div style={{ display: 'flex', gap: 8, marginBottom: 8 }}>
-              <input value={tVal} onChange={e => setTVal(e.target.value)} placeholder="Ключевое слово" />
+            <div style={{ display: 'flex', gap: 8, marginBottom: 8, flexWrap:'wrap' }}>
+              <select value={tKind} onChange={e=>setTKind(e.target.value)}>
+                <option>keyword</option>
+                <option>quick</option>
+                <option>referral</option>
+                <option>story_mention</option>
+                <option>any</option>
+              </select>
+              <input value={tVal} onChange={e=>setTVal(e.target.value)} placeholder="value (для keyword/quick/referral)" />
+              <input type="datetime-local" value={tStart} onChange={e=>setTStart(e.target.value)} />
+              <input type="datetime-local" value={tEnd} onChange={e=>setTEnd(e.target.value)} />
+              <input value={tDaysMask} onChange={e=>setTDaysMask(e.target.value)} placeholder="daysMask (напр. 127)" />
               <button onClick={addTrig}>Добавить</button>
             </div>
             <div>
               {trigs.map(t => (
                 <div key={t.id} style={{ padding: '6px 0', borderBottom: '1px dashed #eee' }}>
-                  keyword: <b>{t.value}</b> • {t.active ? 'on' : 'off'}{' '}
+                  {t.kind}: <b>{t.value}</b> • {t.active ? 'on' : 'off'}{' '}
+                  <button onClick={() => {
+                    const val = prompt('value', t.value);
+                    if (val != null) flowTriggerUpdate(t.id, { value: val }).then(() => flowTriggers(sel.id).then(setTrigs));
+                  }}>edit</button>{' '}
                   <button onClick={() => flowTriggerToggle(t.id).then(() => flowTriggers(sel.id).then(setTrigs))}>
                     toggle
                   </button>

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -217,3 +217,27 @@ export async function flowTriggerToggle(id) {
   return r.json();
 }
 
+export async function flowExport(id) {
+  const r = await fetch(`/api/flows/${id}/export`, { headers: { ...authHeaders() } });
+  if (!r.ok) throw new Error('flow export failed');
+  return r.json();
+}
+export async function flowImport(payload) {
+  const r = await fetch('/api/flows/import', {
+    method:'POST',
+    headers: { 'Content-Type':'application/json', ...authHeaders() },
+    body: JSON.stringify(payload)
+  });
+  if (!r.ok) throw new Error('flow import failed');
+  return r.json();
+}
+export async function flowTriggerUpdate(id, data) {
+  const r = await fetch(`/api/flow-triggers/${id}`, {
+    method:'PUT',
+    headers: { 'Content-Type':'application/json', ...authHeaders() },
+    body: JSON.stringify(data)
+  });
+  if (!r.ok) throw new Error('flow trigger update failed');
+  return r.json();
+}
+

--- a/server/prisma/migrations/20250827140000_flows_triggers_extended/migration.sql
+++ b/server/prisma/migrations/20250827140000_flows_triggers_extended/migration.sql
@@ -1,0 +1,5 @@
+-- Added new trigger fields for time windows and meta
+ALTER TABLE "FlowTrigger" ADD COLUMN "startAt" DATETIME;
+ALTER TABLE "FlowTrigger" ADD COLUMN "endAt" DATETIME;
+ALTER TABLE "FlowTrigger" ADD COLUMN "daysMask" INTEGER;
+ALTER TABLE "FlowTrigger" ADD COLUMN "meta" TEXT;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -94,9 +94,18 @@ model FlowTrigger {
   id        String   @id @default(cuid())
   flowId    String
   flow      Flow     @relation(fields: [flowId], references: [id], onDelete: Cascade)
-  kind      String   // "keyword"
-  value     String   // например "купить", регистронезависимо
+
+  kind      String   // "keyword" | "quick" | "story_mention" | "referral" | "any"
+  value     String   // для keyword/quick/referral (payload/текст); для "any" оставить пустым
+
+  // временные ограничения (опционально)
   active    Boolean  @default(true)
+  startAt   DateTime?
+  endAt     DateTime?
+  daysMask  Int?     // битовая маска дней недели: 1=Mon,2=Tue,...,64=Sun; например 127=все дни
+
+  meta      Json?    // запасное поле для будущих условий
+
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 }


### PR DESCRIPTION
## Summary
- expand FlowTrigger schema with additional kinds, time windows and metadata; add CRUD and import/export endpoints
- match incoming Instagram events against quick reply, keyword, referral, story mention and any triggers
- expose new trigger options, import/export and presets in the client UI

## Testing
- `npx prisma generate` *(fails: Failed to fetch the engine file at https://binaries.prisma.sh/... - 403 Forbidden)*
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af08802e84832c83fae710f59fcf16