### PR TITLE
Refactor JSON handling and add serialization helpers

### DIFF
--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -46,7 +46,7 @@ model IgEvent {
   direction  String   // in | out
   type       String   // text | attachment | postback | system
   text       String?
-  payload    Json?
+  payload    String?  @db.Text
   extId      String?  @unique // внешний ID события (mid или event id)
   at         DateTime @default(now())
 }
@@ -96,7 +96,7 @@ model Flow {
   name       String
   active     Boolean  @default(true)
   entry      String   // id шага-входа
-  nodes      Json     // { [id]: { type, text?, quick?, next?, waitSec? ... } }
+  nodes      String   @db.Text  // { [id]: { type, text?, quick?, next?, waitSec? ... } }
   createdAt  DateTime @default(now())
   updatedAt  DateTime @updatedAt
   triggers   FlowTrigger[]
@@ -116,7 +116,7 @@ model FlowTrigger {
   endAt     DateTime?
   daysMask  Int?     // битовая маска дней недели: 1=Mon,2=Tue,...,64=Sun; например 127=все дни
 
-  meta      Json?    // запасное поле для будущих условий
+  meta      String?  @db.Text    // запасное поле для будущих условий
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -130,7 +130,7 @@ model FlowState {
   nodeId     String
   status     String   @default("running") // running | done | paused
   resumeAt   DateTime?
-  payload    Json?
+  payload    String?  @db.Text
   createdAt  DateTime @default(now())
   updatedAt  DateTime @updatedAt
 }
@@ -140,14 +140,14 @@ model IntegrationError {
   source    String   // 'IG_GRAPH' | 'OPENAI' | 'TELEGRAM' | 'SCHEDULER' | ...
   code      String?
   message   String?
-  meta      Json?
+  meta      String?  @db.Text
   createdAt DateTime @default(now())
 }
 
 model Outbox {
   id        String   @id @default(cuid())
   type      String   // 'IG' | 'OPENAI' | 'TELEGRAM'
-  payload   Json
+  payload   String   @db.Text
   status    String   @default("pending") // pending|sent|error
   attempts  Int      @default(0)
   lastError String?
@@ -156,8 +156,9 @@ model Outbox {
 }
 
 model IgContactTag {
-  id String @id @default(cuid())
-  contactId String
-  tag String
-  createdAt DateTime @default(now())
+  id         String    @id @default(cuid())
+  contactId  String
+  contact    IgContact @relation(fields: [contactId], references: [id], onDelete: Cascade)
+  tag        String
+  createdAt  DateTime  @default(now())
 }

--- a/server/src/routes/ig.ts
+++ b/server/src/routes/ig.ts
@@ -6,6 +6,7 @@ import { notifyManager } from '../services/notify.js';
 import { requireRole } from '../mw/auth.js';
 import { enqueue } from '../services/outbox.js';
 import { startFlow, tickFlow } from '../services/flowEngine.js';
+import { jstr } from '../utils/json.js';
 import { canSend, markSent } from '../services/limits.js';
 import { postHook } from '../services/hooks.js';
 import { withTrace } from '../otel.js';
@@ -129,7 +130,7 @@ export async function registerIGRoutes(app: FastifyInstance) {
                     direction: 'in',
                     type: m.message?.text ? 'text' : m.postback ? 'postback' : 'system',
                     text: text ?? undefined,
-                    payload: m as any,
+                    payload: jstr(m as any),
                     extId
                   },
                   update: {}
@@ -141,7 +142,7 @@ export async function registerIGRoutes(app: FastifyInstance) {
                     direction: 'in',
                     type: m.message?.text ? 'text' : m.postback ? 'postback' : 'system',
                     text: text ?? undefined,
-                    payload: m as any
+                    payload: jstr(m as any)
                   }
                 });
               }
@@ -295,7 +296,7 @@ export async function registerIGRoutes(app: FastifyInstance) {
                       direction: 'out',
                       type: 'rule',
                       text: `hit:${res.meta.keyword || ''}`,
-                      payload: { ruleId: res.meta.ruleId, keyword: res.meta.keyword }
+                      payload: jstr({ ruleId: res.meta.ruleId, keyword: res.meta.keyword })
                     }
                   });
                 }

--- a/server/src/routes/igAdmin.ts
+++ b/server/src/routes/igAdmin.ts
@@ -4,6 +4,7 @@ import { requireAdmin } from '../mw/auth.js';
 import { canSend, markSent } from '../services/limits.js';
 import { igOutMessages, igErrors } from '../metrics.js';
 import { sendIGText } from './ig.js';
+import { jparse } from '../utils/json.js';
 
 export async function registerIgAdminRoutes(app: FastifyInstance) {
   app.addHook('onRequest', (req, reply, done) => requireAdmin(req, reply, done));
@@ -162,7 +163,7 @@ export async function registerIgAdminRoutes(app: FastifyInstance) {
     const events = await prisma.igEvent.findMany({ where, select: { payload: true } });
     const map = new Map<string, number>();
     for (const e of events) {
-      const id = (e.payload as any)?.ruleId || '(unknown)';
+      const id = jparse<any>(e.payload)?.ruleId || '(unknown)';
       map.set(id, (map.get(id) || 0) + 1);
     }
 

--- a/server/src/services/flowEngine.ts
+++ b/server/src/services/flowEngine.ts
@@ -2,6 +2,7 @@ import { prisma } from '../prisma.js';
 import { enqueue } from './outbox.js';
 import { canSend, markSent } from './limits.js';
 import { postHook } from './hooks.js';
+import { jparse } from '../utils/json.js';
 
 // Типы узлов:
 // sendText { type:'sendText', text, next? }
@@ -24,7 +25,7 @@ export async function tickFlow(stateId: string) {
   const flow = await prisma.flow.findUnique({ where: { id: state.flowId } });
   if (!flow) return;
 
-  const nodes = flow.nodes as any;
+  const nodes = jparse<Record<string, any>>(flow.nodes, {});
   const node = nodes[state.nodeId];
   if (!node) {
     await prisma.flowState.update({ where: { id: state.id }, data: { status: 'done' }});

--- a/server/src/services/ilog.ts
+++ b/server/src/services/ilog.ts
@@ -1,7 +1,8 @@
 import { prisma } from '../prisma.js';
+import { jstr } from '../utils/json.js';
 
 function redact(s: any) {
-  let t = JSON.stringify(s ?? {});
+  let t = typeof s === 'string' ? s : jstr(s) || '';
   t = t.replace(/([A-Za-z0-9._%+-]+)@([A-Za-z0-9.-]+\.[A-Za-z]{2,})/g, '***@***');
   t = t.replace(/\b\+?\d{9,15}\b/g, '***masked***');
   t = t.replace(/(access_token|authorization|api[-_ ]?key)["']?\s*:\s*["'][^"']+/gi, '$1:"***"');
@@ -11,7 +12,7 @@ function redact(s: any) {
 export async function logIntegrationError(p:{source:string;code?:string;message?:string;meta?:any}) {
   try {
     await prisma.integrationError.create({
-      data: { source: p.source, code: p.code||null, message: (p.message||'').slice(0,1024), meta: JSON.parse(redact(p.meta)) }
+      data: { source: p.source, code: p.code || null, message: (p.message ?? '').slice(0,1024), meta: redact(p.meta) }
     });
   } catch(e){ console.error('[ilog-fail]', e); }
 }

--- a/server/src/services/outbox.ts
+++ b/server/src/services/outbox.ts
@@ -1,5 +1,6 @@
 import { prisma } from '../prisma.js';
+import { jstr } from '../utils/json.js';
 
 export async function enqueue(type: string, payload: any) {
-  return prisma.outbox.create({ data: { type, payload } });
+  return prisma.outbox.create({ data: { type, payload: jstr(payload) ?? '{}' } });
 }

--- a/server/src/utils/json.ts
+++ b/server/src/utils/json.ts
@@ -1,0 +1,9 @@
+export function jstr(v: any): string | null {
+  if (v === undefined || v === null) return null;
+  try { return JSON.stringify(v); } catch { return null; }
+}
+
+export function jparse<T = any>(s: string | null | undefined, fallback: T = null as any): T {
+  if (!s) return fallback;
+  try { return JSON.parse(s) as T; } catch { return fallback; }
+}


### PR DESCRIPTION
## Summary
- replace Prisma Json columns with String @db.Text and add IgContactTag relation
- add jstr/jparse helpers for JSON serialization/parsing
- use jstr/jparse when storing or reading events, flows, triggers, outbox, and errors

## Testing
- `pnpm exec prisma format` *(fails: Failed to fetch Prisma engine - 403 Forbidden)*
- `pnpm exec prisma generate` *(fails: Failed to fetch Prisma engine - 403 Forbidden)*
- `pnpm exec prisma migrate dev --name "sqlite_json_to_text"` *(fails: Failed to fetch Prisma engine - 403 Forbidden)*
- `npm test` *(fails: Missing script "test"*)

------
https://chatgpt.com/codex/tasks/task_e_68b0359f31b0832c97e6041204eea03b